### PR TITLE
Use individual members in `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
-* @sli-do/team-presentations
+# setup-advancedinstaller project code owners
+
+# Source code is owned by @slidoapp/team-presentations team
+* @DominikPalo @jozefizso @m-kovac @filipbodor 
+
+# CODEOWNERS definitions are owned by admins from @slidoapp/team-presentations-admins team
+.github/CODEOWNERS @DominikPalo @jozefizso


### PR DESCRIPTION
Teams working on this project are not public so we must list individual accounts as owners.